### PR TITLE
Fix Deezer Premium Check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ deezloader/examples/credentials.json
 deezloader/examples/credentials.json
 deezloader/examples/deezer.py
 .gitignore
+.venv/

--- a/deezspot/deezloader/deegw_api.py
+++ b/deezspot/deezloader/deegw_api.py
@@ -107,7 +107,7 @@ class API_GW:
     def get_account_info(cls):
         data = cls.get_user()
         account_info = {
-            'is_premium': data['USER']['OPTIONS'].get('is_premium', False)
+            'is_premium': 'Free' not in data.get('OFFER_NAME')
         }
         return account_info
 

--- a/deezspot/deezloader/deegw_api.py
+++ b/deezspot/deezloader/deegw_api.py
@@ -107,7 +107,7 @@ class API_GW:
     def get_account_info(cls):
         data = cls.get_user()
         account_info = {
-            'is_premium': 'Free' not in data.get('OFFER_NAME')
+            'is_premium': 'Free' not in data.get('OFFER_NAME', 'UNKNOWN')
         }
         return account_info
 


### PR DESCRIPTION
This PR is meant to resolve jakiepari/deezspot#5, issues with the premium check in deezloader's API_GW. I've also added .venv to the .gitignore, if you'd like I can remove that from my branch.

It looks like the json property originally used in the premium check no longer exists. I've confirmed that the OFFER_NAME value is 'Deezer Premium' if using a premium account and 'Deezer Free' if using free. However, I'm unable to test other subscriptions such as duo or family and figured that checking for 'Free' was the safest best. I checked the API docs in hopes of finding the possible options but no luck.

Thanks!